### PR TITLE
chore(release): version 2.0.1

### DIFF
--- a/lib/rudder/analytics/transport.rb
+++ b/lib/rudder/analytics/transport.rb
@@ -8,7 +8,6 @@ require 'rudder/analytics/backoff_policy'
 require 'net/http'
 require 'net/https'
 require 'json'
-require 'pry'
 require 'uri'
 require 'zlib'
 

--- a/lib/rudder/analytics/version.rb
+++ b/lib/rudder/analytics/version.rb
@@ -2,6 +2,6 @@
 
 module Rudder
   class Analytics
-    VERSION = '2.0.0'
+    VERSION = '2.0.1'
   end
 end

--- a/rudder-sdk-ruby.gemspec
+++ b/rudder-sdk-ruby.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'tzinfo', '1.2.1'
   spec.add_development_dependency 'activesupport', '~> 6.0.2'
-  spec.add_development_dependency 'pry', '~> 0.9.12.2'
   if RUBY_VERSION >= '2.0' && RUBY_PLATFORM != 'java'
     spec.add_development_dependency 'oj', '~> 3.6.2'
   end

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ruby
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack Ruby(Async) SDK
-sonar.projectVersion=2.0.0
+sonar.projectVersion=2.0.1
 
 # C/C++/Objective-C related details
 # sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
# Description

Removed `require 'pry'` from transport.rb & gemspec.
