### PR TITLE
fix: configuration ssl to false were always true

### DIFF
--- a/lib/rudder/analytics/transport.rb
+++ b/lib/rudder/analytics/transport.rb
@@ -29,7 +29,7 @@ module Rudder
         uri = URI(config.data_plane_url)
 
         http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = config.ssl || true
+        http.use_ssl = config.ssl.nil? ? true : config.ssl
         http.read_timeout = 8
         http.open_timeout = 4
 


### PR DESCRIPTION
# Description

Hi thinks just was a little mistake here:

Fixing `http.use_ssl` always set to true in `lib/rudder/analytics/transport.rb:32`.

If `ssl` configuration parameters was set to `false` transport itself will always set to true, because `false || true` is always `true`.

I also had some use case in transport specs to verify `ssl` and `gzip` parameters values are passed has expected.

Regards
