### PR TITLE
fix: remove traits at top level

### DIFF
--- a/lib/rudder/analytics/field_parser.rb
+++ b/lib/rudder/analytics/field_parser.rb
@@ -138,6 +138,14 @@ module Rudder
           delete_library_from_context! context
           add_context! context
 
+          # add traits to context if present
+          if fields[:traits]
+              traits = fields[:traits]
+              check_is_hash!(traits, 'traits')
+              isoify_dates! traits
+              context = context.merge({ :traits => traits })
+          end
+
           parsed = {
             :context => context,
             :integrations => fields[:integrations] || { :All => true },
@@ -164,13 +172,7 @@ module Rudder
             isoify_dates! properties
             parsed = parsed.merge({ :properties => properties })
           end
-          # add the traits if present
-          if fields[:traits]
-            traits = fields[:traits]
-            check_is_hash!(traits, 'traits')
-            isoify_dates! traits
-            parsed = parsed.merge({ :traits => traits })
-          end
+
           parsed
         end
 


### PR DESCRIPTION
# Description

This removes `traits` at the top level of the event message since this duplicates traits to be both at the top-level and within `context`.  From discussion in the Slack community, this is only done for legacy scenarios which shouldn't be necessary on latest SDK.  So this removes `traits` at top level and it will continue to be within `context` (so at `context.traits`).

This then matches the Ruby SDK with the behavior of the JS SDK.

Note: I've already signed the Contributor licensing agreement (CLA).