### PR TITLE
Add custom handling for special fields to handle spaces and casing

### DIFF
--- a/lib/rudder/analytics/field_parser.rb
+++ b/lib/rudder/analytics/field_parser.rb
@@ -169,6 +169,37 @@ module Rudder
             traits = fields[:traits]
             check_is_hash!(traits, 'traits')
             isoify_dates! traits
+
+            # Define special fields and create normalized versions for comparison
+            # Source: https://www.rudderstack.com/docs/event-spec/standard-events/identify/#identify-traits
+            special_fields = [
+              'id',
+              'firstName',
+              'lastName',
+              'name',
+              'age',
+              'email',
+              'phone',
+              'address',
+              'birthday',
+              'company',
+              'createdAt',
+              'description',
+              'gender',
+              'title',
+              'username',
+              'website',
+              'avatar'
+            ]
+            
+            normalized_special_fields = special_fields.map { |field| field.to_s.downcase.gsub(' ', '') }
+            
+            # Process special fields
+            special_fields.each_with_index do |field, index|
+              matching_key = traits.keys.find { |k| k.to_s.downcase.gsub(' ', '') == normalized_special_fields[index] }
+              traits[field] = traits.delete(matching_key) if matching_key
+            end
+            
             parsed = parsed.merge({ :traits => traits })
           end
           parsed


### PR DESCRIPTION
# Description

Rudderstack defines special handling of certain traits:
https://www.rudderstack.com/docs/event-spec/standard-events/identify/#identify-traits

For example `createdAt` and `firstName`. The casing and spacing are specific.  

The side effect of this is that if you pass in `Created At` (title case and spaces) it won't be picked up.  In Ruby SDK it will just get included at `Created At` which has unclear implications downstream.

It would be better for the SDK to identify the special fields and ignore spaces and casing. This change proposes this.
