### PR TITLE
feat: add an error callback option to provide the affected data

### DIFF
--- a/lib/rudder/analytics/client.rb
+++ b/lib/rudder/analytics/client.rb
@@ -24,6 +24,7 @@ module Rudder
       # @option opts [FixNum] :max_queue_size Maximum number of calls to be
       #   remain queued.
       # @option opts [Proc] :on_error Handles error calls from the API.
+      # @option opts [Proc] :on_error_with_messages Handles error calls from the API, with failed messages.
       def initialize(opts = {})
         @config = Configuration.new(opts)
         @queue = Queue.new

--- a/lib/rudder/analytics/configuration.rb
+++ b/lib/rudder/analytics/configuration.rb
@@ -7,7 +7,7 @@ module Rudder
     class Configuration
       include Rudder::Analytics::Utils
 
-      attr_reader :write_key, :data_plane_url, :on_error, :stub, :gzip, :ssl, :batch_size, :test, :max_queue_size, :backoff_policy, :retries
+      attr_reader :write_key, :data_plane_url, :on_error, :on_error_with_messages, :stub, :gzip, :ssl, :batch_size, :test, :max_queue_size, :backoff_policy, :retries
 
       def initialize(settings = {})
         symbolized_settings = symbolize_keys(settings)
@@ -18,6 +18,7 @@ module Rudder
         @max_queue_size = symbolized_settings[:max_queue_size] || Defaults::Queue::MAX_SIZE
         @ssl = symbolized_settings[:ssl]
         @on_error = symbolized_settings[:on_error] || proc { |status, error| }
+        @on_error_with_messages = symbolized_settings[:on_error_with_messages] || proc { |status, error, messages| }
         @stub = symbolized_settings[:stub]
         @batch_size = symbolized_settings[:batch_size] || Defaults::MessageBatch::MAX_SIZE
         @gzip = symbolized_settings[:gzip]

--- a/lib/rudder/analytics/message_batch.rb
+++ b/lib/rudder/analytics/message_batch.rb
@@ -26,7 +26,7 @@ module Rudder
           message_json = message.to_json
           # puts message_json
         rescue StandardError => e
-          raise JSONGenerationError, "Serialization error: #{e}"
+          raise JSONGenerationError, "Serialization error: #{e} for message: #{message.inspect}"
         end
 
         message_json_size = message_json.bytesize

--- a/lib/rudder/analytics/version.rb
+++ b/lib/rudder/analytics/version.rb
@@ -2,6 +2,6 @@
 
 module Rudder
   class Analytics
-    VERSION = '3.0.1'
+    VERSION = '3.1.0'
   end
 end


### PR DESCRIPTION
# Description

Currently, when there is an error sending data to Rudderstack, although the caller's callback method would be called, there is no mechanism for the caller to discover which data is affected, thus no way to take the precise action(s) for it.

This change add another callback option which would provide the caller with the data affected by the error, so the caller could act accordingly, such as log the data, or retransmit the data later.

The change is backward compatible. The existing clients still work as they are configured, but could be changed to use this new callback option.
