### PR TITLE
Merging Group Call Traits in Parser

### DIFF
--- a/lib/rudder/analytics/field_parser.rb
+++ b/lib/rudder/analytics/field_parser.rb
@@ -73,6 +73,16 @@ module Rudder
           check_presence!(group_id, 'group_id')
           check_string(group_id, 'group_id')
 
+          # add the traits if present
+          if fields[:traits]
+            traits = fields[:traits]
+            context = common[:context].merge({ :traits => traits })
+
+            common = common.merge({
+              :context => context
+            })
+          end
+
           common.merge({
             :type => 'group',
             :groupId => group_id


### PR DESCRIPTION
# Description

The [Group call](https://www.rudderstack.com/docs/event-spec/standard-events/group/) accepts a `trait` field but never merges it into the context like how it is done in `parse_for_identify`