### PR TITLE
fix: add traits at the root level in group API

### DIFF
--- a/lib/rudder/analytics/field_parser.rb
+++ b/lib/rudder/analytics/field_parser.rb
@@ -73,10 +73,17 @@ module Rudder
           check_presence!(group_id, 'group_id')
           check_string(group_id, 'group_id')
 
-          common.merge({
-            :type => 'group',
-            :groupId => group_id
-          })
+          group_data = {
+            type: 'group',
+            groupId: group_id
+          }
+
+          # Add traits if present
+          if fields[:traits]
+            group_data[:traits] = fields[:traits]
+          end          
+
+          common.merge(group_data)
         end
 
         # In addition to the common fields, page accepts:

--- a/lib/rudder/analytics/version.rb
+++ b/lib/rudder/analytics/version.rb
@@ -2,6 +2,6 @@
 
 module Rudder
   class Analytics
-    VERSION = '3.1.0'
+    VERSION = '3.1.1'
   end
 end


### PR DESCRIPTION
# Description

- As per our Group API event spec. We have started setting `traits` at the root level for the Group event.
- Previously, when traits were passed in the group API (refer to the code below) the SDK was ignoring this value.
```
analytics.group(
  :user_id => user_id,
  :group_id => uid,
  :anonymous_id => anonymous_id,
  # This traits is internally ignored by the Ruby SDK.
  :traits => traits,
  :context => context
)
```
- Now, we have ensured for the above code snippet, we set the traits at the root level.


### Payload

- When traits are passed in the group API:
Code:
```
analytics.group(
  :user_id => user_id,
  :group_id => uid,
  :anonymous_id => anonymous_id,
  :traits => traits,
  :context => context
)
``` 
Payload:
```
{
    "anonymousId": "0ca37a81-ff7d-4941-854b-5d2ad9fa7b66",
    "channel": "server",
    "context": {
        "library": {
            "name": "rudderanalytics-ruby",
            "version": "3.1.1"
        },
        "locale": "en-US",
        "os": {
            "name": "macOS",
            "version": "2.0.2"
        },
        "screen": {
            "density": 3,
            "height": 393,
            "width": 852
        }
    },
    "groupId": "996e0e62-7bf7-49e7-a032-cfa7b870869d",
    "integrations": {
        "All": true
    },
    "messageId": "8ee97dd0-8aeb-4856-8d0d-d1c34cf3ce6c",
    "receivedAt": "2025-02-25T10:41:36.751Z",
    "request_ip": "49.37.33.251",
    "rudderId": "45c7c86e-ee42-4d84-b28b-a13075af6aed",
    "sentAt": "2025-02-25T10:41:35.675Z",
    "timestamp": "2025-02-25T10:41:35.675Z",
    "traits": {
        "Role": "Jedi",
        "age": 25,
        "firstname": "First",
        "lastname": "Last"
    },
    "type": "group",
    "userId": "123456"
}
```
- When traits are not passed in the group API:
Code:
```
analytics.group(
  :user_id => user_id,
  :group_id => uid,
  :anonymous_id => anonymous_id,
  :context => context
)
```
Payload:
```
{
    "anonymousId": "ff6ae703-e0bc-4fd4-a481-d7baf521e153",
    "channel": "server",
    "context": {
        "library": {
            "name": "rudderanalytics-ruby",
            "version": "3.1.1"
        },
        "locale": "en-US",
        "os": {
            "name": "macOS",
            "version": "2.0.2"
        },
        "screen": {
            "density": 3,
            "height": 393,
            "width": 852
        }
    },
    "groupId": "ef919529-3a0f-49e2-a1fd-679fbec32197",
    "integrations": {
        "All": true
    },
    "messageId": "d7ff0d1f-754a-4a2a-ad9e-bd434a351a43",
    "receivedAt": "2025-02-25T10:42:08.155Z",
    "request_ip": "49.37.33.251",
    "rudderId": "ebab8ca3-ef9a-4063-a5b1-b5898f34abde",
    "sentAt": "2025-02-25T10:42:07.216Z",
    "timestamp": "2025-02-25T10:42:07.216Z",
    "type": "group",
    "userId": "123456"
}
```
