### PR TITLE
chore: add DeepWiki badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 <p align="center"><a href="https://rubygems.org/gems/rudder-sdk-ruby"><img src="https://img.shields.io/gem/v/rudder-sdk-ruby?style=flat"/></a></p>
 
+<p align="center"><a href="https://deepwiki.com/rudderlabs/rudder-sdk-ruby"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"/></a></p>
+
 ----
 
 # RudderStack Ruby SDK


### PR DESCRIPTION
# Description

Add a DeepWiki badge to the README.md file. The badge links to the DeepWiki page for this repository (https://deepwiki.com/rudderlabs/rudder-sdk-ruby), providing an easy way for users to access AI-generated documentation and ask questions about the codebase.

## Changes

- Added a centered DeepWiki badge below the existing RubyGems version badge in `README.md`
