### PR TITLE
feat: sdk-4946 implement retry handling in ruby sdk

### DIFF
--- a/lib/rudder/analytics/backoff_policy.rb
+++ b/lib/rudder/analytics/backoff_policy.rb
@@ -15,36 +15,30 @@ module Rudder
       # @option opts [Numeric] :randomization_factor The randomization factor
       #   to use to create a range around the retry interval
       def initialize(opts = {})
-        @min_timeout_ms = opts[:min_timeout_ms] || MIN_TIMEOUT_MS
-        @max_timeout_ms = opts[:max_timeout_ms] || MAX_TIMEOUT_MS
-        @multiplier = opts[:multiplier] || MULTIPLIER
-        @randomization_factor = opts[:randomization_factor] || RANDOMIZATION_FACTOR
+        @min_timeout_ms = [opts[:min_timeout_ms] || MIN_TIMEOUT_MS, 0].max
+        @max_timeout_ms = [opts[:max_timeout_ms] || MAX_TIMEOUT_MS, 0].max
+        @multiplier = [opts[:multiplier] || MULTIPLIER, 0].max
+        @randomization_factor = [[opts[:randomization_factor] || RANDOMIZATION_FACTOR, 0].max, 1].min
 
         @attempts = 0
       end
 
       # @return [Numeric] the next backoff interval, in milliseconds.
-      def next_interval
-        interval = @min_timeout_ms * (@multiplier**@attempts)
+      def next_interval(floor_ms = 0)
+        interval = [@min_timeout_ms * (@multiplier**@attempts), @max_timeout_ms].min
+        interval = [interval, floor_ms].max
         interval = add_jitter(interval, @randomization_factor)
 
         @attempts += 1
-
-        [interval, @max_timeout_ms].min
+        interval
       end
 
       private
 
       def add_jitter(base, randomization_factor)
-        random_number = rand
-        max_deviation = base * randomization_factor
-        deviation = random_number * max_deviation
+        return base if base <= 0 || randomization_factor <= 0
 
-        if random_number < 0.5
-          base - deviation
-        else
-          base + deviation
-        end
+        base + (rand * base * randomization_factor)
       end
     end
   end

--- a/lib/rudder/analytics/configuration.rb
+++ b/lib/rudder/analytics/configuration.rb
@@ -8,8 +8,8 @@ module Rudder
       include Rudder::Analytics::Utils
 
       attr_reader :write_key, :data_plane_url, :on_error, :on_error_with_messages, :stub, :gzip, :ssl, :batch_size,
-                  :test, :max_queue_size, :backoff_policy, :retries, :max_retries, :retry_base_delay,
-                  :max_retry_delay, :retry_jitter_ratio, :respect_retry_after
+                  :test, :max_queue_size, :backoff_policy, :retries, :retry_base_delay, :max_retry_delay,
+                  :retry_jitter_ratio, :respect_retry_after
 
       def initialize(settings = {})
         symbolized_settings = symbolize_keys(settings)
@@ -36,21 +36,12 @@ module Rudder
 
       def configure_retry(settings)
         @retries = settings[:retries]
-        @max_retries = normalize_max_retries(settings)
         @retry_base_delay = normalize_non_negative_integer(settings[:retry_base_delay])
         @max_retry_delay = normalize_non_negative_integer(
           settings[:max_retry_delay] || settings[:maximum_backoff_duration]
         )
         @retry_jitter_ratio = normalize_jitter_ratio(settings[:retry_jitter_ratio])
         @respect_retry_after = normalize_respect_retry_after(settings)
-      end
-
-      def normalize_max_retries(settings)
-        if settings.has_key?(:max_retries)
-          [settings[:max_retries].to_i, 0].max
-        elsif settings.has_key?(:retries)
-          [settings[:retries].to_i - 1, 0].max
-        end
       end
 
       def normalize_non_negative_integer(value)

--- a/lib/rudder/analytics/configuration.rb
+++ b/lib/rudder/analytics/configuration.rb
@@ -7,7 +7,9 @@ module Rudder
     class Configuration
       include Rudder::Analytics::Utils
 
-      attr_reader :write_key, :data_plane_url, :on_error, :on_error_with_messages, :stub, :gzip, :ssl, :batch_size, :test, :max_queue_size, :backoff_policy, :retries
+      attr_reader :write_key, :data_plane_url, :on_error, :on_error_with_messages, :stub, :gzip, :ssl, :batch_size,
+                  :test, :max_queue_size, :backoff_policy, :retries, :max_retries, :retry_base_delay,
+                  :max_retry_delay, :retry_jitter_ratio, :respect_retry_after
 
       def initialize(settings = {})
         symbolized_settings = symbolize_keys(settings)
@@ -23,11 +25,50 @@ module Rudder
         @batch_size = symbolized_settings[:batch_size] || Defaults::MessageBatch::MAX_SIZE
         @gzip = symbolized_settings[:gzip]
         @backoff_policy = symbolized_settings[:backoff_policy]
-        @retries = symbolized_settings[:retries]
+        configure_retry(symbolized_settings)
         raise ArgumentError, 'Missing required option :write_key' \
           unless @write_key
         raise ArgumentError, 'Data plane url must be initialized' \
           unless @data_plane_url
+      end
+
+      private
+
+      def configure_retry(settings)
+        @retries = settings[:retries]
+        @max_retries = normalize_max_retries(settings)
+        @retry_base_delay = normalize_non_negative_integer(settings[:retry_base_delay])
+        @max_retry_delay = normalize_non_negative_integer(
+          settings[:max_retry_delay] || settings[:maximum_backoff_duration]
+        )
+        @retry_jitter_ratio = normalize_jitter_ratio(settings[:retry_jitter_ratio])
+        @respect_retry_after = normalize_respect_retry_after(settings)
+      end
+
+      def normalize_max_retries(settings)
+        if settings.has_key?(:max_retries)
+          [settings[:max_retries].to_i, 0].max
+        elsif settings.has_key?(:retries)
+          [settings[:retries].to_i - 1, 0].max
+        end
+      end
+
+      def normalize_non_negative_integer(value)
+        return nil if value.nil?
+
+        [value.to_i, 0].max
+      end
+
+      def normalize_jitter_ratio(value)
+        return nil if value.nil?
+
+        [[value.to_f, 0.0].max, 1.0].min
+      end
+
+      def normalize_respect_retry_after(settings)
+        return nil unless settings.has_key?(:respect_retry_after)
+
+        settings[:respect_retry_after] ? true : false
       end
     end
   end

--- a/lib/rudder/analytics/defaults.rb
+++ b/lib/rudder/analytics/defaults.rb
@@ -10,8 +10,8 @@ module Rudder
         HEADERS = { 'Accept' => 'application/json',
                     'Content-Type' => 'application/json',
                     'Content-Encoding' => 'gzip' }
-        MAX_RETRIES = 3
-        RETRIES = MAX_RETRIES + 1
+        RETRIES = 10
+        MAX_RETRIES = RETRIES - 1
       end
 
       module Queue
@@ -29,9 +29,9 @@ module Rudder
 
       module BackoffPolicy
         MIN_TIMEOUT_MS = 100
-        MAX_TIMEOUT_MS = 30000
-        MULTIPLIER = 2
-        RANDOMIZATION_FACTOR = 0.2
+        MAX_TIMEOUT_MS = 10000
+        MULTIPLIER = 1.5
+        RANDOMIZATION_FACTOR = 0.5
       end
     end
   end

--- a/lib/rudder/analytics/defaults.rb
+++ b/lib/rudder/analytics/defaults.rb
@@ -10,7 +10,8 @@ module Rudder
         HEADERS = { 'Accept' => 'application/json',
                     'Content-Type' => 'application/json',
                     'Content-Encoding' => 'gzip' }
-        RETRIES = 10
+        MAX_RETRIES = 3
+        RETRIES = MAX_RETRIES + 1
       end
 
       module Queue
@@ -28,9 +29,9 @@ module Rudder
 
       module BackoffPolicy
         MIN_TIMEOUT_MS = 100
-        MAX_TIMEOUT_MS = 10000
-        MULTIPLIER = 1.5
-        RANDOMIZATION_FACTOR = 0.5
+        MAX_TIMEOUT_MS = 30000
+        MULTIPLIER = 2
+        RANDOMIZATION_FACTOR = 0.2
       end
     end
   end

--- a/lib/rudder/analytics/defaults.rb
+++ b/lib/rudder/analytics/defaults.rb
@@ -29,9 +29,9 @@ module Rudder
 
       module BackoffPolicy
         MIN_TIMEOUT_MS = 100
-        MAX_TIMEOUT_MS = 10000
-        MULTIPLIER = 1.5
-        RANDOMIZATION_FACTOR = 0.5
+        MAX_TIMEOUT_MS = 30000
+        MULTIPLIER = 2
+        RANDOMIZATION_FACTOR = 0.2
       end
     end
   end

--- a/lib/rudder/analytics/field_parser.rb
+++ b/lib/rudder/analytics/field_parser.rb
@@ -74,14 +74,12 @@ module Rudder
           check_string(group_id, 'group_id')
 
           group_data = {
-            type: 'group',
-            groupId: group_id
+            :type => 'group',
+            :groupId => group_id
           }
 
           # Add traits if present
-          if fields[:traits]
-            group_data[:traits] = fields[:traits]
-          end          
+          group_data[:traits] = fields[:traits] if fields[:traits]
 
           common.merge(group_data)
         end

--- a/lib/rudder/analytics/retry_policy.rb
+++ b/lib/rudder/analytics/retry_policy.rb
@@ -32,7 +32,7 @@ module Rudder
       def self.from_config(config)
         backoff_policy = config.backoff_policy || Rudder::Analytics::BackoffPolicy.new(backoff_options(config))
         new(
-          :max_retries => config.max_retries.nil? ? MAX_RETRIES : config.max_retries,
+          :retries => config.retries.nil? ? RETRIES : config.retries,
           :respect_retry_after => config.respect_retry_after.nil? ? true : config.respect_retry_after,
           :backoff_policy => backoff_policy
         )
@@ -48,7 +48,7 @@ module Rudder
       end
 
       def initialize(options = {})
-        @max_retries = options[:max_retries] || MAX_RETRIES
+        @max_retries = normalize_max_retries(options)
         @respect_retry_after = options.has_key?(:respect_retry_after) ? options[:respect_retry_after] : true
         @backoff_policy = options[:backoff_policy] || Rudder::Analytics::BackoffPolicy.new
       end
@@ -71,6 +71,16 @@ module Rudder
       end
 
       private
+
+      def normalize_max_retries(options)
+        if options.has_key?(:max_retries)
+          [options[:max_retries].to_i, 0].max
+        elsif options.has_key?(:retries)
+          [options[:retries].to_i - 1, 0].max
+        else
+          MAX_RETRIES
+        end
+      end
 
       def next_backoff_interval(retry_after_delay)
         if @backoff_policy.method(:next_interval).arity.zero?

--- a/lib/rudder/analytics/retry_policy.rb
+++ b/lib/rudder/analytics/retry_policy.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rudder/analytics/backoff_policy'
+require 'rudder/analytics/defaults'
+require 'net/http'
+require 'net/https'
+require 'time'
+
+module Rudder
+  class Analytics
+    class RetryPolicy
+      include Rudder::Analytics::Defaults::Request
+
+      RETRYABLE_ERRORS = [
+        Timeout::Error,
+        EOFError,
+        IOError,
+        SocketError,
+        Errno::ECONNREFUSED,
+        Errno::ECONNRESET,
+        Errno::EHOSTUNREACH,
+        Errno::ENETUNREACH,
+        Errno::ETIMEDOUT,
+        Net::OpenTimeout,
+        Net::ReadTimeout,
+        Net::ProtocolError,
+        OpenSSL::SSL::SSLError
+      ].freeze
+
+      attr_reader :backoff_policy, :max_retries
+
+      def self.from_config(config)
+        backoff_policy = config.backoff_policy || Rudder::Analytics::BackoffPolicy.new(backoff_options(config))
+        new(
+          :max_retries => config.max_retries.nil? ? MAX_RETRIES : config.max_retries,
+          :respect_retry_after => config.respect_retry_after.nil? ? true : config.respect_retry_after,
+          :backoff_policy => backoff_policy
+        )
+      end
+
+      def self.backoff_options(config)
+        {
+          :min_timeout_ms => config.retry_base_delay || BackoffPolicy::MIN_TIMEOUT_MS,
+          :max_timeout_ms => config.max_retry_delay || BackoffPolicy::MAX_TIMEOUT_MS,
+          :multiplier => BackoffPolicy::MULTIPLIER,
+          :randomization_factor => config.retry_jitter_ratio || BackoffPolicy::RANDOMIZATION_FACTOR
+        }
+      end
+
+      def initialize(options = {})
+        @max_retries = options[:max_retries] || MAX_RETRIES
+        @respect_retry_after = options.has_key?(:respect_retry_after) ? options[:respect_retry_after] : true
+        @backoff_policy = options[:backoff_policy] || Rudder::Analytics::BackoffPolicy.new
+      end
+
+      def max_attempts
+        @max_retries + 1
+      end
+
+      def retryable_status_code?(status_code)
+        status_code.zero? || status_code == 429 || (status_code >= 500 && status_code <= 599)
+      end
+
+      def retryable_exception?(exception)
+        RETRYABLE_ERRORS.any? { |error_class| exception.is_a?(error_class) }
+      end
+
+      def retry_delay_in_seconds(headers = {})
+        interval = next_backoff_interval(retry_after_delay_in_milliseconds(headers))
+        interval.to_f / 1000
+      end
+
+      private
+
+      def next_backoff_interval(retry_after_delay)
+        if @backoff_policy.method(:next_interval).arity.zero?
+          [@backoff_policy.next_interval, retry_after_delay].max
+        else
+          @backoff_policy.next_interval(retry_after_delay)
+        end
+      end
+
+      def retry_after_delay_in_milliseconds(headers)
+        return 0 unless @respect_retry_after
+
+        value = header_value(headers, 'Retry-After')
+        return 0 if value.nil?
+
+        parse_retry_after_delay(value)
+      end
+
+      def header_value(headers, name)
+        headers.find { |header_name, _| header_name.to_s.casecmp(name).zero? }&.last
+      end
+
+      def parse_retry_after_delay(value)
+        value = value.to_s.strip
+        return value.to_i * 1000 if value.match?(/\A\d+\z/)
+
+        retry_at = Time.httpdate(value)
+        [((retry_at - Time.now) * 1000).ceil, 0].max
+      rescue ArgumentError
+        0
+      end
+    end
+  end
+end

--- a/lib/rudder/analytics/transport.rb
+++ b/lib/rudder/analytics/transport.rb
@@ -5,6 +5,7 @@ require 'rudder/analytics/utils'
 require 'rudder/analytics/response'
 require 'rudder/analytics/logging'
 require 'rudder/analytics/backoff_policy'
+require 'rudder/analytics/retry_policy'
 require 'net/http'
 require 'net/https'
 require 'json'
@@ -23,8 +24,9 @@ module Rudder
       def initialize(config)
         @stub = config.stub || false
         @path = PATH
-        @retries = config.retries || RETRIES
-        @backoff_policy = config.backoff_policy || Rudder::Analytics::BackoffPolicy.new
+        @retry_policy = Rudder::Analytics::RetryPolicy.from_config(config)
+        @retries = @retry_policy.max_attempts
+        @backoff_policy = @retry_policy.backoff_policy
 
         uri = URI(config.data_plane_url)
 
@@ -37,88 +39,92 @@ module Rudder
         @gzip = config.gzip.nil? ? true : config.gzip
       end
 
-      # Sends a batch of messages to the API
-      #
-      # @return [Response] API response
       def send(write_key, batch)
         logger.debug("Sending request for #{batch.length} items")
 
-        last_response, exception = retry_with_backoff(@retries) do
-          status_code, body = send_request(write_key, batch)
-          error = body
-          # rudder server now return 'OK'
-          # begin
-          #     error = JSON.parse(body)['error']
-          # rescue StandardError
-          #   error = JSON.parse(body.to_json)
-          #       end
+        retries = 0
 
-          # puts error
-          should_retry = should_retry_request?(status_code, body)
-          logger.debug("Response status code: #{status_code}")
-          logger.debug("Response error: #{error}") if error
+        loop do
+          begin
+            response, headers = build_response(write_key, batch)
+            return response unless should_retry_request?(response.status, response.error)
+            return response unless retries_remaining?(retries)
 
-          [Response.new(status_code, error), should_retry]
-        end
+            retries = retry_request(retries, headers, "status #{response.status}")
+          rescue StandardError => e
+            return error_response(e) unless retryable_exception?(e)
+            return error_response(e) unless retries_remaining?(retries)
 
-        if exception
-          logger.error(exception.message)
-          exception.backtrace.each { |line| logger.error(line) }
-          Response.new(-1, exception.to_s)
-        else
-          last_response
+            retries = retry_exception(retries, e)
+          end
         end
       end
 
-      # Closes a persistent connection if it exists
       def shutdown
         @http.finish if @http.started?
       end
 
       private
 
+      def build_response(write_key, batch)
+        status_code, body, headers = send_request(write_key, batch)
+        error = body
+        logger.debug("Response status code: #{status_code}")
+        logger.debug("Response error: #{error}") if error
+
+        [Response.new(status_code, error), headers]
+      end
+
+      def retries_remaining?(retries)
+        retries < @retry_policy.max_retries
+      end
+
+      def retry_request(retries, headers, reason)
+        retries += 1
+        sleep_before_retry(retries, headers, reason)
+        retries
+      end
+
+      def retry_exception(retries, exception)
+        retries += 1
+        reset_connection
+        sleep_before_retry(retries, {}, exception.class.name)
+        retries
+      end
+
       def should_retry_request?(status_code, body)
-        if status_code >= 500
-          true # Server error
-        elsif status_code == 429
-          true # Rate limited
-        elsif status_code >= 400
-          logger.error(body)
-          false # Client error. Do not retry, but log
-        else
-          false
-        end
+        logger.error(body) if status_code >= 400 && !retryable_status_code?(status_code)
+
+        retryable_status_code?(status_code)
       end
 
-      # Takes a block that returns [result, should_retry].
-      #
-      # Retries upto `retries_remaining` times, if `should_retry` is false or
-      # an exception is raised. `@backoff_policy` is used to determine the
-      # duration to sleep between attempts
-      #
-      # Returns [last_result, raised_exception]
-      def retry_with_backoff(retries_remaining, &block)
-        result, caught_exception = nil
-        should_retry = false
-
-        begin
-          result, should_retry = yield
-          return [result, nil] unless should_retry
-        rescue StandardError => e
-          should_retry = true
-          caught_exception = e
-        end
-
-        if should_retry && (retries_remaining > 1)
-          logger.debug("Retrying request, #{retries_remaining} retries left")
-          sleep(@backoff_policy.next_interval.to_f / 1000)
-          retry_with_backoff(retries_remaining - 1, &block)
-        else
-          [result, caught_exception]
-        end
+      def retryable_status_code?(status_code)
+        @retry_policy.retryable_status_code?(status_code)
       end
 
-      # Sends a request for the batch, returns [status_code, body]
+      def retryable_exception?(exception)
+        @retry_policy.retryable_exception?(exception)
+      end
+
+      def sleep_before_retry(retry_number, headers, reason)
+        delay = @retry_policy.retry_delay_in_seconds(headers)
+        remaining = @retry_policy.max_retries - retry_number
+        logger.debug("Retrying request after #{reason}, #{remaining} retries left")
+        sleep(delay) if delay.positive?
+      end
+
+      def error_response(exception)
+        logger.error(exception.message)
+        exception.backtrace&.each { |line| logger.error(line) }
+        Response.new(-1, exception.to_s)
+      end
+
+      def reset_connection
+        @http.finish if @http.started?
+      rescue StandardError
+        nil
+      end
+
       def send_request(write_key, batch)
         payload = {
           :batch => batch.messages
@@ -127,26 +133,38 @@ module Rudder
           logger.debug "stubbed request to #{@path}: " \
             "write key = #{write_key}, batch = #{JSON.generate(payload)}"
 
-          [200, '{}']
+          [200, '{}', {}]
         else
 
-          headers = HEADERS
-
-          if @gzip
-            gzip = Zlib::GzipWriter.new(StringIO.new)
-            gzip << payload.to_json
-            payload = gzip.close.string
-          else
-            headers.delete('Content-Encoding')
-            payload = JSON.generate(payload)
-          end
+          payload, headers = encoded_payload(payload)
 
           request = Net::HTTP::Post.new(@path, headers)
           request.basic_auth(write_key, nil)
           @http.start unless @http.started? # Maintain a persistent connection
           response = @http.request(request, payload)
-          [response.code.to_i, response.body]
+          [response.code.to_i, response.body, response_headers(response)]
         end
+      end
+
+      def encoded_payload(payload)
+        headers = HEADERS.dup
+
+        if @gzip
+          gzip = Zlib::GzipWriter.new(StringIO.new)
+          gzip << payload.to_json
+          payload = gzip.close.string
+        else
+          headers.delete('Content-Encoding')
+          payload = JSON.generate(payload)
+        end
+
+        [payload, headers]
+      end
+
+      def response_headers(response)
+        headers = {}
+        response.each_header { |name, value| headers[name] = value }
+        headers
       end
     end
   end

--- a/lib/rudder/analytics/transport.rb
+++ b/lib/rudder/analytics/transport.rb
@@ -88,7 +88,7 @@ module Rudder
       def retry_exception(retries, exception)
         retries += 1
         reset_connection
-        sleep_before_retry(retries, {}, exception.class.name)
+        sleep_before_retry(retries, {}, "transport error #{exception.class.name}")
         retries
       end
 
@@ -109,7 +109,8 @@ module Rudder
       def sleep_before_retry(retry_number, headers, reason)
         delay = @retry_policy.retry_delay_in_seconds(headers)
         remaining = @retry_policy.max_retries - retry_number
-        logger.debug("Retrying request after #{reason}, #{remaining} retries left")
+        logger.debug("Retrying request after #{reason} in #{delay}s " \
+                     "(attempt #{retry_number} of #{@retry_policy.max_attempts}, #{remaining} retries left)")
         sleep(delay) if delay.positive?
       end
 

--- a/lib/rudder/analytics/worker.rb
+++ b/lib/rudder/analytics/worker.rb
@@ -47,8 +47,8 @@ module Rudder
 
           # res = Request.new(:data_plane_url => @data_plane_url, :ssl => @ssl).post @write_key, @batch
           res = @transport.send @write_key, @batch
-          unless res.status == 200
-            @on_error.call(res.status, res.error) 
+          unless success_status?(res.status)
+            @on_error.call(res.status, res.error)
             @on_error_with_messages.call(res.status, res.error, @batch.messages)
           end
 
@@ -65,6 +65,10 @@ module Rudder
       end
 
       private
+
+      def success_status?(status)
+        status >= 200 && status < 300
+      end
 
       def consume_message_from_queue!
         @batch << @queue.pop

--- a/spec/integration/retry_contract_spec.rb
+++ b/spec/integration/retry_contract_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'webrick'
+
+$LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
+require 'rudder/analytics'
+
+class ImmediateBackoffPolicy
+  def initialize(intervals)
+    @intervals = intervals
+  end
+
+  def next_interval
+    raise 'ImmediateBackoffPolicy has no intervals left' if @intervals.empty?
+
+    @intervals.shift
+  end
+end
+
+RSpec.describe 'retry behavior over a local HTTP boundary' do
+  def drain_queue(queue)
+    items = []
+    loop { items << queue.pop(true) }
+  rescue ThreadError
+    items
+  end
+
+  def start_retrying_server(captured_requests)
+    request_count = 0
+    mutex = Mutex.new
+    server = WEBrick::HTTPServer.new(
+      :BindAddress => '127.0.0.1',
+      :Port => 0,
+      :Logger => WEBrick::Log.new($stderr, WEBrick::Log::FATAL),
+      :AccessLog => [],
+      :DoNotReverseLookup => true
+    )
+
+    server.mount_proc('/v1/batch') do |request, response|
+      captured_requests << {
+        :path => request.path,
+        :authorization => request['authorization'],
+        :content_type => request['content-type'],
+        :content_encoding => request['content-encoding'],
+        :body => request.body
+      }
+
+      current_request = mutex.synchronize { request_count += 1 }
+      if current_request == 1
+        response.status = 429
+        response.body = 'Too Many Requests'
+      else
+        response.status = 200
+        response['Content-Type'] = 'application/json'
+        response.body = '{}'
+      end
+    end
+
+    server_thread = Thread.new { server.start }
+    [server, server_thread, server.listeners.first.addr[1]]
+  end
+
+  it 'retries a 429 and resends the same batch through the public API' do
+    captured_requests = Queue.new
+    captured_errors = Queue.new
+    server, server_thread, port = start_retrying_server(captured_requests)
+
+    begin
+      analytics = Rudder::Analytics.new(
+        :write_key => 'testsecret',
+        :data_plane_url => "http://127.0.0.1:#{port}",
+        :ssl => false,
+        :gzip => false,
+        :retries => 2,
+        :backoff_policy => ImmediateBackoffPolicy.new([0]),
+        :on_error => proc { |status, error| captured_errors << [status, error] }
+      )
+
+      analytics.track(
+        :user_id => 'user-1',
+        :event => 'Retry Contract Event',
+        :message_id => 'message-1'
+      )
+      analytics.flush
+
+      requests = drain_queue(captured_requests)
+      errors = drain_queue(captured_errors)
+
+      expect(errors).to be_empty
+      expect(requests.length).to eq(2)
+      expect(requests[0][:path]).to eq('/v1/batch')
+      expect(requests[0][:authorization]).to match(/\ABasic /)
+      expect(requests[0][:content_type]).to eq('application/json')
+      expect(requests[0][:content_encoding]).to be_nil
+      expect(requests[0][:body]).to eq(requests[1][:body])
+
+      payload = JSON.parse(requests[0][:body])
+      event = payload['batch'].first
+
+      expect(event['type']).to eq('track')
+      expect(event['userId']).to eq('user-1')
+      expect(event['event']).to eq('Retry Contract Event')
+      expect(event['messageId']).to eq('message-1')
+    ensure
+      server.shutdown
+      server_thread.join(5)
+    end
+  end
+end

--- a/spec/integration/retry_contract_spec.rb
+++ b/spec/integration/retry_contract_spec.rb
@@ -18,6 +18,19 @@ class ImmediateBackoffPolicy
   end
 end
 
+class RecordingBackoffPolicy
+  attr_reader :floors
+
+  def initialize
+    @floors = []
+  end
+
+  def next_interval(floor_ms = 0)
+    @floors << floor_ms
+    0
+  end
+end
+
 RSpec.describe 'retry behavior over a local HTTP boundary' do
   def drain_queue(queue)
     items = []
@@ -26,7 +39,7 @@ RSpec.describe 'retry behavior over a local HTTP boundary' do
     items
   end
 
-  def start_retrying_server(captured_requests)
+  def start_server(captured_requests, response_sequence)
     request_count = 0
     mutex = Mutex.new
     server = WEBrick::HTTPServer.new(
@@ -47,13 +60,14 @@ RSpec.describe 'retry behavior over a local HTTP boundary' do
       }
 
       current_request = mutex.synchronize { request_count += 1 }
-      if current_request == 1
-        response.status = 429
-        response.body = 'Too Many Requests'
-      else
-        response.status = 200
-        response['Content-Type'] = 'application/json'
-        response.body = '{}'
+      response_definition = response_sequence.fetch(
+        [current_request - 1, response_sequence.length - 1].min
+      )
+
+      response.status = response_definition.fetch(:status)
+      response.body = response_definition.fetch(:body, '{}')
+      response_definition.fetch(:headers, {}).each do |name, value|
+        response[name] = value
       end
     end
 
@@ -61,10 +75,11 @@ RSpec.describe 'retry behavior over a local HTTP boundary' do
     [server, server_thread, server.listeners.first.addr[1]]
   end
 
-  it 'retries a 429 and resends the same batch through the public API' do
+  def exercise_public_api(response_sequence, backoff_policy: ImmediateBackoffPolicy.new([0]), retries: 2)
     captured_requests = Queue.new
     captured_errors = Queue.new
-    server, server_thread, port = start_retrying_server(captured_requests)
+    captured_errors_with_messages = Queue.new
+    server, server_thread, port = start_server(captured_requests, response_sequence)
 
     begin
       analytics = Rudder::Analytics.new(
@@ -72,9 +87,12 @@ RSpec.describe 'retry behavior over a local HTTP boundary' do
         :data_plane_url => "http://127.0.0.1:#{port}",
         :ssl => false,
         :gzip => false,
-        :retries => 2,
-        :backoff_policy => ImmediateBackoffPolicy.new([0]),
-        :on_error => proc { |status, error| captured_errors << [status, error] }
+        :retries => retries,
+        :backoff_policy => backoff_policy,
+        :on_error => proc { |status, error| captured_errors << [status, error] },
+        :on_error_with_messages => proc do |status, error, messages|
+          captured_errors_with_messages << [status, error, messages.map(&:dup)]
+        end
       )
 
       analytics.track(
@@ -84,27 +102,110 @@ RSpec.describe 'retry behavior over a local HTTP boundary' do
       )
       analytics.flush
 
-      requests = drain_queue(captured_requests)
-      errors = drain_queue(captured_errors)
-
-      expect(errors).to be_empty
-      expect(requests.length).to eq(2)
-      expect(requests[0][:path]).to eq('/v1/batch')
-      expect(requests[0][:authorization]).to match(/\ABasic /)
-      expect(requests[0][:content_type]).to eq('application/json')
-      expect(requests[0][:content_encoding]).to be_nil
-      expect(requests[0][:body]).to eq(requests[1][:body])
-
-      payload = JSON.parse(requests[0][:body])
-      event = payload['batch'].first
-
-      expect(event['type']).to eq('track')
-      expect(event['userId']).to eq('user-1')
-      expect(event['event']).to eq('Retry Contract Event')
-      expect(event['messageId']).to eq('message-1')
+      {
+        :requests => drain_queue(captured_requests),
+        :errors => drain_queue(captured_errors),
+        :errors_with_messages => drain_queue(captured_errors_with_messages)
+      }
     ensure
       server.shutdown
       server_thread.join(5)
     end
+  end
+
+  def expect_valid_event_request(request)
+    expect(request[:path]).to eq('/v1/batch')
+    expect(request[:authorization]).to match(/\ABasic /)
+    expect(request[:content_type]).to eq('application/json')
+    expect(request[:content_encoding]).to be_nil
+
+    event = JSON.parse(request[:body])['batch'].first
+    expect(event['type']).to eq('track')
+    expect(event['userId']).to eq('user-1')
+    expect(event['event']).to eq('Retry Contract Event')
+    expect(event['messageId']).to eq('message-1')
+  end
+
+  it 'sends an event once when the server returns 200' do
+    result = exercise_public_api([{ :status => 200 }])
+
+    expect(result[:requests].length).to eq(1)
+    expect_valid_event_request(result[:requests].first)
+    expect(result[:errors]).to be_empty
+    expect(result[:errors_with_messages]).to be_empty
+  end
+
+  it 'does not retry a terminal 404 response' do
+    result = exercise_public_api([{ :status => 404, :body => 'Not Found' }])
+
+    expect(result[:requests].length).to eq(1)
+    expect(result[:errors]).to eq([[404, 'Not Found']])
+    expect(result[:errors_with_messages].length).to eq(1)
+
+    status, error, messages = result[:errors_with_messages].first
+    expect(status).to eq(404)
+    expect(error).to eq('Not Found')
+    expect(messages.first[:messageId]).to eq('message-1')
+  end
+
+  it 'retries a 429 and resends the same batch through the public API' do
+    response_sequence = [
+      { :status => 429, :body => 'Too Many Requests' },
+      { :status => 200 }
+    ]
+    result = exercise_public_api(response_sequence)
+
+    requests = result[:requests]
+    expect(result[:errors]).to be_empty
+    expect(result[:errors_with_messages]).to be_empty
+    expect(requests.length).to eq(2)
+    expect(requests[0][:body]).to eq(requests[1][:body])
+    expect_valid_event_request(requests.first)
+  end
+
+  [500, 501, 502, 503].each do |status_code|
+    it "retries a #{status_code} response and succeeds" do
+      response_sequence = [
+        { :status => status_code, :body => 'Server Error' },
+        { :status => 200 }
+      ]
+      result = exercise_public_api(response_sequence)
+
+      requests = result[:requests]
+      expect(requests.length).to eq(2)
+      expect(requests[0][:body]).to eq(requests[1][:body])
+      expect(result[:errors]).to be_empty
+      expect(result[:errors_with_messages]).to be_empty
+    end
+  end
+
+  it 'returns the final error after the retry budget is exhausted' do
+    response_sequence = [
+      { :status => 503, :body => 'Unavailable' },
+      { :status => 503, :body => 'Still Unavailable' }
+    ]
+    result = exercise_public_api(response_sequence)
+
+    requests = result[:requests]
+    expect(requests.length).to eq(2)
+    expect(requests[0][:body]).to eq(requests[1][:body])
+    expect(result[:errors]).to eq([[503, 'Still Unavailable']])
+    expect(result[:errors_with_messages].length).to eq(1)
+    expect(result[:errors_with_messages].first[2].first[:messageId]).to eq('message-1')
+  end
+
+  it 'passes Retry-After delay seconds from the HTTP response to the backoff policy' do
+    backoff_policy = RecordingBackoffPolicy.new
+    result = exercise_public_api(
+      [
+        { :status => 429, :body => 'Too Many Requests', :headers => { 'Retry-After' => '2' } },
+        { :status => 200 }
+      ],
+      :backoff_policy => backoff_policy
+    )
+
+    expect(result[:requests].length).to eq(2)
+    expect(backoff_policy.floors).to eq([2000])
+    expect(result[:errors]).to be_empty
   end
 end

--- a/spec/rudder/analytics/backoff_policy_spec.rb
+++ b/spec/rudder/analytics/backoff_policy_spec.rb
@@ -7,6 +7,17 @@ module Rudder
     describe BackoffPolicy do
       describe '#initialize' do
         context 'no options are given' do
+          it 'uses the shared SDK backoff defaults' do
+            defaults = [
+              described_class::MIN_TIMEOUT_MS,
+              described_class::MAX_TIMEOUT_MS,
+              described_class::MULTIPLIER,
+              described_class::RANDOMIZATION_FACTOR
+            ]
+
+            expect(defaults).to eq([100, 30000, 2, 0.2])
+          end
+
           it 'sets default min_timeout_ms' do
             actual = subject.instance_variable_get(:@min_timeout_ms)
             expect(actual).to eq(described_class::MIN_TIMEOUT_MS)

--- a/spec/rudder/analytics/backoff_policy_spec.rb
+++ b/spec/rudder/analytics/backoff_policy_spec.rb
@@ -85,8 +85,37 @@ module Rudder
         end
 
         it 'caps maximum duration at max_timeout_secs' do
-          10.times { subject.next_interval }
-          expect(subject.next_interval).to eq(10000)
+          policy = described_class.new(
+            min_timeout_ms: 1000,
+            max_timeout_ms: 10000,
+            multiplier: 2,
+            randomization_factor: 0
+          )
+
+          10.times { policy.next_interval }
+          expect(policy.next_interval).to eq(10000)
+        end
+
+        it 'uses Retry-After as a floor on backoff' do
+          policy = described_class.new(
+            min_timeout_ms: 100,
+            max_timeout_ms: 10000,
+            multiplier: 2,
+            randomization_factor: 0
+          )
+
+          expect(policy.next_interval(2000)).to eq(2000)
+        end
+
+        it 'does not let Retry-After shorten backoff' do
+          policy = described_class.new(
+            min_timeout_ms: 1000,
+            max_timeout_ms: 10000,
+            multiplier: 2,
+            randomization_factor: 0
+          )
+
+          expect(policy.next_interval(100)).to eq(1000)
         end
       end
     end

--- a/spec/rudder/analytics/configuration_spec.rb
+++ b/spec/rudder/analytics/configuration_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Rudder
+  class Analytics
+    describe Configuration do
+      subject {
+        described_class.new(
+          :write_key => 'write_key',
+          :data_plane_url => 'data_plane_url',
+          :retries => 4
+        )
+      }
+
+      it 'keeps retries as the public retry budget setting' do
+        expect(subject.retries).to eq(4)
+      end
+
+      it 'does not expose max_retries as a separate configuration setting' do
+        expect(subject).to_not respond_to(:max_retries)
+      end
+    end
+  end
+end

--- a/spec/rudder/analytics/transport_spec.rb
+++ b/spec/rudder/analytics/transport_spec.rb
@@ -265,7 +265,7 @@ module Rudder
                 :backoff_policy => backoff_policy,
                 :data_plane_url => 'http://localhost:8080/v1/batch',
                 :write_key => 'write_key',
-                :max_retries => 3,
+                :retries => 4,
                 :gzip => false
               })
             }
@@ -300,7 +300,7 @@ module Rudder
                 :backoff_policy => FakeBackoffPolicy.new([0]),
                 :data_plane_url => 'http://localhost:8080/v1/batch',
                 :write_key => 'write_key',
-                :max_retries => 1,
+                :retries => 2,
                 :gzip => false
               })
               transport = described_class.new(config)

--- a/spec/rudder/analytics/transport_spec.rb
+++ b/spec/rudder/analytics/transport_spec.rb
@@ -284,6 +284,23 @@ module Rudder
               expect(subject.send(write_key, batch).status).to eq(200)
             end
 
+            it 'logs response retry details' do
+              http = subject.instance_variable_get(:@http)
+              responses = [
+                build_response(429, 'Too Many Requests'),
+                build_response(200, '{}')
+              ]
+
+              expect(http).to receive(:request).twice do
+                responses.shift
+              end
+              expect(subject.logger)
+                .to receive(:debug)
+                .with('Retrying request after status 429 in 0.0s (attempt 1 of 4, 2 retries left)')
+
+              subject.send(write_key, batch)
+            end
+
             it 'does not retry terminal client errors' do
               http = subject.instance_variable_get(:@http)
               expect(http).to receive(:request).once do
@@ -333,6 +350,26 @@ module Rudder
               end
 
               expect(subject.send(write_key, batch).status).to eq(200)
+            end
+
+            it 'logs transport error retry details' do
+              http = subject.instance_variable_get(:@http)
+              responses = [Net::OpenTimeout.new('timeout'), build_response(200, '{}')]
+
+              expect(http).to receive(:request).twice do
+                response = responses.shift
+                raise response if response.is_a?(Exception)
+
+                response
+              end
+              expect(subject.logger)
+                .to receive(:debug)
+                .with(
+                  'Retrying request after transport error Net::OpenTimeout in 0.0s ' \
+                  '(attempt 1 of 4, 2 retries left)'
+                )
+
+              subject.send(write_key, batch)
             end
 
             it 'resends the same event payload after a 429' do

--- a/spec/rudder/analytics/transport_spec.rb
+++ b/spec/rudder/analytics/transport_spec.rb
@@ -69,6 +69,7 @@ module Rudder
               :backoff_policy => backoff_policy,
               :data_plane_url => 'http://localhost:8080/v1/batch',
               :write_key => 'write_key',
+              :retries => retries,
               :ssl => false,
               :gzip => false
             })
@@ -101,6 +102,13 @@ module Rudder
       end
 
       describe '#send' do
+        def build_response(status_code, response_body = '{}', headers = {})
+          response = Net::HTTPResponse.new(1.1, status_code, response_body)
+          allow(response).to receive(:body) { response_body }
+          headers.each { |name, value| response.add_field(name, value) }
+          response
+        end
+
         let(:response) {
           Net::HTTPResponse.new(http_version, status_code, response_body)
         }
@@ -238,6 +246,176 @@ module Rudder
             it_behaves_like('retried request', 429, '{}')
             it_behaves_like('non-retried request', 404, '{}')
             it_behaves_like('non-retried request', 400, '{}')
+          end
+
+          it 'classifies retryable status codes' do
+            expect(subject.__send__(:retryable_status_code?, 0)).to eq(true)
+            expect(subject.__send__(:retryable_status_code?, 429)).to eq(true)
+            expect(subject.__send__(:retryable_status_code?, 500)).to eq(true)
+            expect(subject.__send__(:retryable_status_code?, 599)).to eq(true)
+            expect(subject.__send__(:retryable_status_code?, 400)).to eq(false)
+            expect(subject.__send__(:retryable_status_code?, 404)).to eq(false)
+            expect(subject.__send__(:retryable_status_code?, 422)).to eq(false)
+          end
+
+          context 'with retry configuration' do
+            let(:backoff_policy) { FakeBackoffPolicy.new([0, 0, 0]) }
+            let(:config) {
+              Configuration.new({
+                :backoff_policy => backoff_policy,
+                :data_plane_url => 'http://localhost:8080/v1/batch',
+                :write_key => 'write_key',
+                :max_retries => 3,
+                :gzip => false
+              })
+            }
+            subject { described_class.new(config) }
+
+            it 'retries 429 until success' do
+              http = subject.instance_variable_get(:@http)
+              responses = [
+                build_response(429, 'Too Many Requests'),
+                build_response(200, '{}')
+              ]
+
+              expect(http).to receive(:request).twice do
+                responses.shift
+              end
+              expect(subject.send(write_key, batch).status).to eq(200)
+            end
+
+            it 'does not retry terminal client errors' do
+              http = subject.instance_variable_get(:@http)
+              expect(http).to receive(:request).once do
+                build_response(400, 'Bad Request')
+              end
+
+              response = subject.send(write_key, batch)
+
+              expect(response.status).to eq(400)
+            end
+
+            it 'returns the last retryable response after the retry budget is exhausted' do
+              config = Configuration.new({
+                :backoff_policy => FakeBackoffPolicy.new([0]),
+                :data_plane_url => 'http://localhost:8080/v1/batch',
+                :write_key => 'write_key',
+                :max_retries => 1,
+                :gzip => false
+              })
+              transport = described_class.new(config)
+              http = transport.instance_variable_get(:@http)
+              responses = [
+                build_response(429, 'Too Many Requests'),
+                build_response(429, 'Still Limited')
+              ]
+
+              allow(http).to receive(:start)
+              expect(http).to receive(:request).twice do
+                responses.shift
+              end
+
+              response = transport.send(write_key, batch)
+
+              expect(response.status).to eq(429)
+              expect(response.error).to eq('Still Limited')
+            end
+
+            it 'retries retryable network exceptions' do
+              http = subject.instance_variable_get(:@http)
+              responses = [Net::OpenTimeout.new('timeout'), build_response(200, '{}')]
+
+              expect(http).to receive(:request).twice do
+                response = responses.shift
+                raise response if response.is_a?(Exception)
+
+                response
+              end
+
+              expect(subject.send(write_key, batch).status).to eq(200)
+            end
+
+            it 'resends the same event payload after a 429' do
+              message_batch = MessageBatch.new(100)
+              message_batch << {
+                :type => 'track',
+                :userId => 'user-1',
+                :event => 'Retry Contract Event',
+                :messageId => 'message-1'
+              }
+              http = subject.instance_variable_get(:@http)
+              responses = [
+                build_response(429, 'Too Many Requests'),
+                build_response(200, '{}')
+              ]
+              payloads = []
+
+              expect(http).to receive(:request).twice do |_request, payload|
+                payloads << payload
+                responses.shift
+              end
+
+              response = subject.send(write_key, message_batch)
+              parsed_payload = JSON.parse(payloads.first)
+
+              expect(response.status).to eq(200)
+              expect(payloads.length).to eq(2)
+              expect(payloads[0]).to eq(payloads[1])
+              expect(parsed_payload['batch'].first['messageId']).to eq('message-1')
+              expect(parsed_payload['batch'].first['event']).to eq('Retry Contract Event')
+            end
+          end
+
+          context 'with Retry-After headers' do
+            it 'uses Retry-After as a floor on backoff' do
+              config = Configuration.new({
+                :backoff_policy => FakeBackoffPolicy.new([100]),
+                :data_plane_url => 'http://localhost:8080/v1/batch',
+                :write_key => 'write_key'
+              })
+              transport = described_class.new(config)
+              retry_policy = transport.instance_variable_get(:@retry_policy)
+
+              expect(retry_policy.retry_delay_in_seconds({ 'Retry-After' => '2' })).to eq(2)
+            end
+
+            it 'does not let Retry-After shorten backoff' do
+              config = Configuration.new({
+                :backoff_policy => FakeBackoffPolicy.new([1000]),
+                :data_plane_url => 'http://localhost:8080/v1/batch',
+                :write_key => 'write_key'
+              })
+              transport = described_class.new(config)
+              retry_policy = transport.instance_variable_get(:@retry_policy)
+
+              expect(retry_policy.retry_delay_in_seconds({ 'Retry-After' => '1' })).to eq(1)
+            end
+
+            it 'honors Retry-After HTTP dates' do
+              retry_at = (Time.now + 2).httpdate
+              config = Configuration.new({
+                :backoff_policy => FakeBackoffPolicy.new([0]),
+                :data_plane_url => 'http://localhost:8080/v1/batch',
+                :write_key => 'write_key'
+              })
+              transport = described_class.new(config)
+              retry_policy = transport.instance_variable_get(:@retry_policy)
+
+              expect(retry_policy.retry_delay_in_seconds({ 'Retry-After' => retry_at })).to be >= 1
+            end
+
+            it 'can disable Retry-After handling' do
+              config = Configuration.new({
+                :backoff_policy => FakeBackoffPolicy.new([100]),
+                :data_plane_url => 'http://localhost:8080/v1/batch',
+                :write_key => 'write_key',
+                :respect_retry_after => false
+              })
+              transport = described_class.new(config)
+              retry_policy = transport.instance_variable_get(:@retry_policy)
+
+              expect(retry_policy.retry_delay_in_seconds({ 'Retry-After' => '2' })).to eq(0.1)
+            end
           end
         end
       end

--- a/spec/rudder/analytics/worker_spec.rb
+++ b/spec/rudder/analytics/worker_spec.rb
@@ -91,7 +91,7 @@ module Rudder
             status, error, data = yielded_status, yielded_error, yielded_data.dup
           end
 
-          message = { context: {:ip=>"127.0.0.1"}, type: "identify", traits: { email: "test@test.com" } }
+          message = { context: { :ip => '127.0.0.1' }, type: 'identify', traits: { email: 'test@test.com' } }
           queue = Queue.new
           queue << message
           config = Configuration.new({ :on_error_with_messages => on_error_with_messages, :write_key => 'write_key', :data_plane_url => 'data_plane_url' })
@@ -109,6 +109,29 @@ module Rudder
           expect(status).to eq(400)
           expect(error).to eq('Some error')
           expect(data).to eq([message])
+        end
+
+        it 'does not execute error handlers for successful non-200 responses' do
+          Rudder::Analytics::Transport
+            .any_instance
+            .stub(:send)
+            .and_return(Rudder::Analytics::Response.new(201, 'Accepted'))
+
+          on_error = proc { raise 'on_error should not be called' }
+          on_error_with_messages = proc { raise 'on_error_with_messages should not be called' }
+          queue = Queue.new
+          queue << {}
+          config = Configuration.new({
+            :on_error => on_error,
+            :on_error_with_messages => on_error_with_messages,
+            :write_key => 'write_key',
+            :data_plane_url => 'data_plane_url'
+          })
+          worker = described_class.new(queue, config)
+
+          expect { worker.run }.to_not raise_error
+
+          Rudder::Analytics::Transport.any_instance.unstub(:send)
         end
 
         # it 'does not call on_error if the request is good' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,13 @@
 # https://github.com/codecov/codecov-ruby#usage
 require 'simplecov'
 SimpleCov.start
-require 'codecov'
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
+
+# The legacy Codecov Ruby uploader is opt-in so normal test runs do not fail
+# while attempting to upload coverage from every RSpec process.
+unless ENV['CODECOV_TOKEN'].to_s.empty?
+  require 'codecov'
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+end
 
 require 'rudder/analytics'
 require 'active_support/time'


### PR DESCRIPTION
## Summary

Implements the Rust/PHP-style retry baseline for the Ruby SDK delivery path:

- Adds a retry policy for retryable HTTP statuses and network/timeouts.
- Retries 429, status 0, and 5xx responses with bounded exponential backoff.
- Honors `Retry-After` delay-seconds and HTTP-date values as a floor over client backoff.
- Keeps terminal client errors non-retryable.
- Preserves the same event payload across retries.

## Validation

- `bundle exec rspec` -> 153 examples, 0 failures
- Targeted RuboCop on touched files -> no offenses
- `git diff --check` -> clean

Linear: https://linear.app/rudderstack/issue/SDK-4946/implement-retry-handling-in-ruby-sync-sdk


---

## Local integration contract test

Included a local integration contract spec that spins up an in-process WEBrick server and verifies the public SDK path retries a 429, resends the same batch, and succeeds without invoking error callbacks.

Run it with:

```sh
bundle exec rspec spec/integration/retry_contract_spec.rb
```
