### PR TITLE
chore(codeowners): set sdk_team as code owners

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "BUG : <Title>"
 labels: bug, open source
-assignees: ""
+assignees: []
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "BUG : <Title>"
 labels: bug, open source
-assignees: "@rudderlabs/sdk_team"
+assignees: ""
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "BUG : <Title>"
 labels: bug, open source
-assignees: pallabmaiti
+assignees: "@rudderlabs/sdk_team"
 ---
 
 **Describe the bug**

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pallabmaiti @bardisg
+* @rudderlabs/sdk_team


### PR DESCRIPTION
# Description

Replaces the repo's code owners — currently two named individuals (`@pallabmaiti`, `@bardisg`) — with the whole SDK team (`@rudderlabs/sdk_team`), so any team member's review can unblock chore PRs (Dependabot merges, CI fixes) instead of hard-blocking whenever a specific person is unavailable. Part of the SDK-5102 rollout across SDK repos; resolves SDK-5112.

Changes:

- `CODEOWNERS` (repo root): `* @pallabmaiti @bardisg` → `* @rudderlabs/sdk_team`; also adds the missing trailing newline.
- `.github/ISSUE_TEMPLATE/bug_report.md`: default assignee replaced with an empty list (was `pallabmaiti`) — GitHub issue assignees only accept individual users, so a team can't be set here.

Notes:

- `@rudderlabs/sdk_team` already has write access on this repo, so GitHub honors it as code owner as soon as this merges — no access changes needed.
- Review-routing change only — no code, workflow, or build behavior is affected.
- Post-merge check: the next PR should auto-request review from `sdk_team`, and any member's approval should satisfy the code-owner requirement.


